### PR TITLE
MSVC11 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,13 +8,21 @@ add_definitions("-O3")
 
 add_definitions(-DMLOGDEBUG)
 add_definitions(-DMLOGTRACE)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")	
+
+if(GCC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")	
+endif()
 #add_definitions(-DMLOG_NO_LIB)
 
 # boost
 # you should define BOOST_ROOT first
 find_package(Boost COMPONENTS system filesystem unit_test_framework)
 include_directories(Boost_INCLUDE_DIR ${Boost_INCLUDE_DIRS})
+if(MSVC)
+    # disable auto link on windows
+    # to support use dynamic boost lib
+    add_definitions(-DBOOST_ALL_NO_LIB)
+endif()
 
 
 #includes
@@ -38,7 +46,13 @@ if (CMAKE_CXX_COMPILER MATCHES ".*clang")
         target_link_libraries(test c++)
 	#add_definitions(-DBOOST_TEST_DYN_LINK) 
 else()
- 	message("using gcc.")
+    if(GCC)
+        message("using gcc.")
+    elseif(MSVC)
+        message("using msvc.")
+    else()
+        message("using known compiler.")
+    endif()
 	add_definitions(-DBOOST_TEST_DYN_LINK)
 endif()
 

--- a/mlog/thread_safe.hpp
+++ b/mlog/thread_safe.hpp
@@ -6,6 +6,11 @@
 #ifndef __THREAD_SAFE_HPP__
 #define __THREAD_SAFE_HPP__
 
+#if defined( BOOST_NO_CXX11_VARIADIC_TEMPLATES )
+    #include <boost/preprocessor/repetition.hpp>
+    #include <boost/preprocessor/control/if.hpp>
+#endif
+
 #include <boost/detail/lightweight_mutex.hpp>
 #include <boost/config.hpp>
 #include "logger.hpp"
@@ -28,10 +33,15 @@ public:
 	}
 
 #else
-	thread_safe()
-	:logger_type()
-	{
-	}
+
+#define CTOR(z, n, unused)\
+    BOOST_PP_IF(n, template<,) BOOST_PP_ENUM_PARAMS(n, typename Arg) BOOST_PP_IF(n, >,)\
+	thread_safe(BOOST_PP_ENUM_BINARY_PARAMS(n, Arg, arg))\
+    :logger_type(BOOST_PP_ENUM_PARAMS(n, arg)) {}
+
+BOOST_PP_REPEAT(5, CTOR, ~)
+#undef CTOR
+
 #endif // ! defined( BOOST_NO_CXX11_VARIADIC_TEMPLATES )
 
 	virtual ~thread_safe()


### PR DESCRIPTION
1. use boost preprocessor to support variadic templates in msvc
2. use `find_package` to find boost library
3. some cmake files changes to support msvc
