### PR TITLE
Moved properties from logger_base to mlog_manager.

### DIFF
--- a/manager.hpp
+++ b/manager.hpp
@@ -1,0 +1,66 @@
+/*
+ * mlog.hpp
+ *
+ *  Created on: Aug 12, 2012
+ *      Author: philipp
+ */
+
+#ifndef _MLOG_MANAGER_HPP_
+#define _MLOG_MANAGER_HPP_
+
+#include <atomic>
+#include <memory>
+
+namespace mlog {
+
+struct standard_logger;
+struct logger_base;
+
+struct mlog_manager {
+
+	mlog_manager();
+	~mlog_manager() {
+		// This should not be cleaned up
+		// https://github.com/zschoche/mlog/issues/11
+	}
+
+	inline logger_base *log() { return m_log; }
+
+	void set_log(logger_base &log) { set_log(&log); }
+
+	void set_log(logger_base *log);
+
+	void unset_log() { this->set_log(nullptr); }
+
+	template <typename T> inline void use_thread_id(T &&value) {
+		m_use_thread_id = std::forward<T>(value);
+	}
+
+	inline bool use_thread_id() const { return m_use_thread_id; }
+
+	template <typename T> inline void use_time(T &&value) {
+		m_use_time = std::forward<T>(value);
+	}
+
+	inline bool use_time() const { return m_use_time; }
+
+	template <typename T> inline void use_position(T &&value) {
+		m_use_position = std::forward<T>(value);
+	}
+
+	inline bool use_position() const { return m_use_position; }
+	inline bool session() const { return m_session; }
+
+      private:
+	std::atomic<logger_base *> m_log;
+	std::atomic<bool> m_is_valid;
+
+	short m_session;
+	bool m_use_time;
+	bool m_use_thread_id;
+	bool m_use_position;
+};
+} /* namespace mlog */
+#endif /* _MLOG_MANAGER_HPP_ */
+
+

--- a/mlog/impl/logger.hpp
+++ b/mlog/impl/logger.hpp
@@ -8,7 +8,6 @@
 #define __LOGGER_IPP__
 
 #include "../logger.hpp"
-#include <boost/random.hpp>
 #include <cstdio>
 #if _MSC_VER
 #define snprintf _snprintf_s
@@ -174,22 +173,7 @@ std::ostream &log_metadata::output(std::ostream &stream) const {
 	return stream;
 }
 
-logger_base::logger_base()
-    : m_use_time(false), m_use_thread_id(false), m_use_position(false) {
-	using namespace boost;
-	using namespace boost::random;
-	mt19937 rng(std::time(0));
-
-#ifdef BOOST_HAS_TR1_RANDOM
-	uniform_int_distribution<> six(0, 100);
-	m_session = six(rng);
-#elseif
-	boost::uniform_int<> six(0, 100);
-	boost::variate_generator<boost::mt19937 &, boost::uniform_int<> > die(
-	    rng, six);
-	m_session = die();
-#endif
-}
+logger_base::logger_base() { }
 
 logger_base::~logger_base() {
 	if(mlog::manager->log() == this)

--- a/mlog/impl/mlog.hpp
+++ b/mlog/impl/mlog.hpp
@@ -9,11 +9,44 @@
 #define __MLOG_IPP__
 
 #include "../mlog.hpp"
+#include <boost/random.hpp>
 
 namespace mlog {
 
-	// This should not be cleaned up https://github.com/zschoche/mlog/issues/11
-	mlog_manager* manager = new mlog_manager();
+// This should not be cleaned up https://github.com/zschoche/mlog/issues/11
+mlog_manager *manager = new mlog_manager();
+
+mlog_manager::mlog_manager()
+    : m_log(new standard_logger()), m_is_valid(false), m_use_time(false),
+      m_use_thread_id(false), m_use_position(false) {
+	using namespace boost;
+	using namespace boost::random;
+	mt19937 rng(std::time(0));
+
+#ifdef BOOST_HAS_TR1_RANDOM
+	uniform_int_distribution<> six(0, 100);
+	m_session = six(rng);
+#elseif
+	boost::uniform_int<> six(0, 100);
+	boost::variate_generator<boost::mt19937 &, boost::uniform_int<> > die(
+	    rng, six);
+	m_session = die();
+#endif
+}
+
+void mlog_manager::set_log(logger_base *log) {
+	logger_base *old_log = m_log;
+
+	if (log == nullptr) {
+		m_log = new standard_logger();
+	} else {
+		m_log = log;
+	}
+
+	if (!m_is_valid)
+		delete old_log;
+	m_is_valid = log != nullptr;
+}
 }
 
 #endif

--- a/mlog/logger.hpp
+++ b/mlog/logger.hpp
@@ -28,6 +28,7 @@ using boost::thread;
 #endif
 #include <chrono>
 #include <boost/format.hpp>
+#include "manager.hpp"
 
 enum mlog_level {
 	trace,
@@ -39,6 +40,8 @@ enum mlog_level {
 };
 
 namespace mlog {
+
+extern mlog_manager *manager;
 
 template <typename T> inline std::string level_to_string(T &&level) {
 	if (level == mlog_level::trace)
@@ -108,33 +111,33 @@ struct logger_base {
 
 	inline void write(mlog_level &&level, boost::format &&format,
 			  log_position &&pos) {
-		log_metadata metadata(std::move(level), m_session, m_use_time,
-				      m_use_thread_id, std::move(pos),
-				      m_use_position);
+		log_metadata metadata(std::move(level), mlog::manager->session(), mlog::manager->use_time(),
+				      mlog::manager->use_thread_id(), std::move(pos),
+				      mlog::manager->use_position());
 		write_to_log(std::move(metadata), boost::str(format));
 	}
 
 	inline void write(mlog_level &&level, const boost::format &format,
 			  log_position &&pos) {
-		log_metadata metadata(std::move(level), m_session, m_use_time,
-				      m_use_thread_id, std::move(pos),
-				      m_use_position);
+		log_metadata metadata(std::move(level), mlog::manager->session(), mlog::manager->use_time(),
+				       mlog::manager->use_thread_id(), std::move(pos),
+				      mlog::manager->use_position());
 		write_to_log(std::move(metadata), boost::str(format));
 	}
 
 	inline void write(mlog_level &&level, std::string &&log_text,
 			  log_position &&pos) {
-		log_metadata metadata(std::move(level), m_session, m_use_time,
-				      m_use_thread_id, std::move(pos),
-				      m_use_position);
+		log_metadata metadata(std::move(level), mlog::manager->session(), mlog::manager->use_time(),
+				      mlog::manager->use_thread_id(), std::move(pos),
+				      mlog::manager->use_position());
 		write_to_log(std::move(metadata), std::move(log_text));
 	}
 
 	template <typename T>
 	void write(mlog_level &&level, const std::string &log_text, T &&pos) {
-		log_metadata metadata(std::move(level), m_session, m_use_time,
-				      m_use_thread_id, std::forward<T>(pos),
-				      m_use_position);
+		log_metadata metadata(std::move(level), mlog::manager->session(), mlog::manager->use_time(),
+				       mlog::manager->use_thread_id(), std::forward<T>(pos),
+				      mlog::manager->use_position());
 		write_to_log(std::move(metadata), std::string(log_text));
 	}
 
@@ -145,29 +148,7 @@ struct logger_base {
 	virtual void write_to_log(const log_metadata& metadata,
 				  const std::string& log_text) = 0;
 
-	template <typename T> inline void use_thread_id(T &&value) {
-		m_use_thread_id = std::forward<T>(value);
-	}
 
-	inline bool use_thread_id() const { return m_use_thread_id; }
-
-	template <typename T> inline void use_time(T &&value) {
-		m_use_time = std::forward<T>(value);
-	}
-
-	inline bool use_time() const { return m_use_time; }
-
-	template <typename T> inline void use_position(T &&value) {
-		m_use_position = std::forward<T>(value);
-	}
-
-	inline bool use_position() const { return m_use_position; }
-
-      private:
-	short m_session;
-	bool m_use_time;
-	bool m_use_thread_id;
-	bool m_use_position;
 };
 
 template<typename T>

--- a/mlog/mlog.hpp
+++ b/mlog/mlog.hpp
@@ -11,61 +11,22 @@
 #include "logger.hpp"
 #include "thread_safe.hpp"
 #include "standard_logger.hpp"
+#include "manager.hpp"
 #include <atomic>
 #include <memory>
 
 namespace mlog {
 
-struct mlog_manager {
-
-		mlog_manager() : m_log(new standard_logger()), m_is_valid(false) {}
-		~mlog_manager() {
-			// This should not be cleaned up https://github.com/zschoche/mlog/issues/11
-		}
-
-		inline logger_base* log() {
-			return m_log;
-		}
-
-		void set_log(logger_base& log) {
-			set_log(&log);
-		}
-
-		void set_log(logger_base* log) {
-			logger_base* old_log = m_log;
-
-			if(log == nullptr) {
-				m_log = new standard_logger();
-			} else {
-				m_log = log;
-			}
-
-			if(!m_is_valid)
-				delete old_log;
-			m_is_valid = log != nullptr;
-		}
-
-		void unset_log() {
-			this->set_log(nullptr);
-		}
-
-	private:
-		std::atomic<logger_base*> m_log;
-		std::atomic<bool> m_is_valid;
-
-
-};
-
-
 // This should not be cleaned up https://github.com/zschoche/mlog/issues/11
-extern mlog_manager* manager;
+extern mlog_manager *manager;
 
 }; /* namespace mlog */
 
 #ifdef MLOGTRACE
 #define MLOG_TRACE(x1)                                                         \
-	::mlog::manager->log()->write(mlog_level::trace, x1,                          \
-			       ::mlog::log_position(__FILE__, __LINE__))
+	::mlog::manager->log()->write(                                         \
+				    mlog_level::trace, x1,                     \
+				    ::mlog::log_position(__FILE__, __LINE__))
 
 #else
 #define MLOG_TRACE(x1)
@@ -73,27 +34,32 @@ extern mlog_manager* manager;
 
 #ifdef MLOGDEBUG
 #define MLOG_DEBUG(x1)                                                         \
-	::mlog::manager->log()->write(mlog_level::debug, x1,                          \
-			       ::mlog::log_position(__FILE__, __LINE__))
+	::mlog::manager->log()->write(                                         \
+				    mlog_level::debug, x1,                     \
+				    ::mlog::log_position(__FILE__, __LINE__))
 #else
 #define MLOG_DEBUG(x1)
 #endif
 
 #define MLOG_INFO(x1)                                                          \
-	::mlog::manager->log()->write(mlog_level::info, x1,                           \
-			       ::mlog::log_position(__FILE__, __LINE__))
+	::mlog::manager->log()->write(                                         \
+				    mlog_level::info, x1,                      \
+				    ::mlog::log_position(__FILE__, __LINE__))
 
 #define MLOG_WARNING(x1)                                                       \
-	::mlog::manager->log()->write(mlog_level::warning, x1,                        \
-			       ::mlog::log_position(__FILE__, __LINE__))
+	::mlog::manager->log()->write(                                         \
+				    mlog_level::warning, x1,                   \
+				    ::mlog::log_position(__FILE__, __LINE__))
 
 #define MLOG_ERROR(x1)                                                         \
-	::mlog::manager->log()->write(mlog_level::error, x1,                          \
-			       ::mlog::log_position(__FILE__, __LINE__))
+	::mlog::manager->log()->write(                                         \
+				    mlog_level::error, x1,                     \
+				    ::mlog::log_position(__FILE__, __LINE__))
 
 #define MLOG_FATAL(x1)                                                         \
-	::mlog::manager->log()->write(mlog_level::fatal, x1,                          \
-			       ::mlog::log_position(__FILE__, __LINE__))
+	::mlog::manager->log()->write(                                         \
+				    mlog_level::fatal, x1,                     \
+				    ::mlog::log_position(__FILE__, __LINE__))
 
 #endif /* MLOG_HPP_ */
 

--- a/test_src/test.cpp
+++ b/test_src/test.cpp
@@ -151,21 +151,21 @@ BOOST_AUTO_TEST_CASE(standard_logger_speed_test) {
 	mlog::standard_logger stdlog;
 	mlog::manager->set_log(stdlog);
 	double st_result = single_thread_test();
-	mlog::manager->log()->use_thread_id(true);
+	mlog::manager->use_thread_id(true);
 	double st_result_thread_id = single_thread_test();
-	mlog::manager->log()->use_time(true);
+	mlog::manager->use_time(true);
 	double st_result_thread_id_time = single_thread_test();
-	mlog::manager->log()->use_position(true);
+	mlog::manager->use_position(true);
 	double st_result_thread_id_time_pos = single_thread_test();
 
 	mlog::standard_logger_thread_safe stdlog_thread_safe;
 	mlog::manager->set_log(stdlog_thread_safe);
 	double mt_result = single_thread_test();
-	mlog::manager->log()->use_thread_id(true);
+	mlog::manager->use_thread_id(true);
 	double mt_result_thread_id = single_thread_test();
-	mlog::manager->log()->use_time(true);
+	mlog::manager->use_time(true);
 	double mt_result_thread_id_time = single_thread_test();
-	mlog::manager->log()->use_position(true);
+	mlog::manager->use_position(true);
 	double mt_result_thread_id_time_pos = single_thread_test();
 
 	std::cout << std::endl;
@@ -199,11 +199,11 @@ BOOST_AUTO_TEST_CASE(memory_logger_speed_test) {
 	mlog::memory_logger_normal log;
 	mlog::manager->set_log(log);
 	double st_result = single_thread_test();
-	mlog::manager->log()->use_thread_id(true);
+	mlog::manager->use_thread_id(true);
 	double st_result_thread_id = single_thread_test();
-	mlog::manager->log()->use_time(true);
+	mlog::manager->use_time(true);
 	double st_result_thread_id_time = single_thread_test();
-	mlog::manager->log()->use_position(true);
+	mlog::manager->use_position(true);
 	double st_result_thread_id_time_pos = single_thread_test();
 
 	std::cout << std::endl;
@@ -224,24 +224,24 @@ BOOST_AUTO_TEST_CASE(file_logger_speed_test) {
 	num_loops = 100000;
 	mlog::file_logger log("log.txt");
 	mlog::manager->set_log(log);
-	mlog::manager->log()->use_time(false);
+	mlog::manager->use_time(false);
 	double st_result = single_thread_test();
-	mlog::manager->log()->use_thread_id(true);
+	mlog::manager->use_thread_id(true);
 	double st_result_thread_id = single_thread_test();
-	mlog::manager->log()->use_time(true);
+	mlog::manager->use_time(true);
 	double st_result_thread_id_time = single_thread_test();
-	mlog::manager->log()->use_position(true);
+	mlog::manager->use_position(true);
 	double st_result_thread_id_time_pos = single_thread_test();
 
 	mlog::file_logger_thread_safe log_thread_safe("log.txt");
 	mlog::manager->set_log(log_thread_safe);
-	mlog::manager->log()->use_time(false);
+	mlog::manager->use_time(false);
 	double mt_result = single_thread_test();
-	mlog::manager->log()->use_thread_id(true);
+	mlog::manager->use_thread_id(true);
 	double mt_result_thread_id = single_thread_test();
-	mlog::manager->log()->use_time(true);
+	mlog::manager->use_time(true);
 	double mt_result_thread_id_time = single_thread_test();
-	mlog::manager->log()->use_position(true);
+	mlog::manager->use_position(true);
 	double mt_result_thread_id_time_pos = single_thread_test();
 
 	std::cout << std::endl;
@@ -272,9 +272,9 @@ BOOST_AUTO_TEST_CASE(memory_logger_test) {
 	num_loops = 100000;
 	mlog::memory_logger<2048> log;
 	mlog::manager->set_log(log);
-	mlog::manager->log()->use_time(false);
-	mlog::manager->log()->use_thread_id(false);
-	mlog::manager->log()->use_time(false);
+	mlog::manager->use_time(false);
+	mlog::manager->use_thread_id(false);
+	mlog::manager->use_time(false);
 
 	for (std::size_t i = 0; i < 2048; i++) {
 		MLOG_INFO(boost::format("%1%") % i);
@@ -290,9 +290,9 @@ BOOST_AUTO_TEST_CASE(memory_logger_test_small) {
 	num_loops = 100000;
 	mlog::memory_logger<4> mem_log;
 	mlog::manager->set_log(mem_log);
-	mlog::manager->log()->use_time(false);
-	mlog::manager->log()->use_thread_id(false);
-	mlog::manager->log()->use_time(false);
+	mlog::manager->use_time(false);
+	mlog::manager->use_thread_id(false);
+	mlog::manager->use_time(false);
 
 	for (std::size_t i = 0; i < 1024 * 1024; i++) {
 		MLOG_INFO(boost::format("%1%") % i);


### PR DESCRIPTION
Moved properties from logger_base to mlog_manager because these properties doesn't work correct with mlog::thread safe<> and mlog::async_logger.
